### PR TITLE
Update README.md with current documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Contents
 
 Documentation
 -------------
-[`kiss-ui` docs hosted on Github Pages](http://cybergeek94.github.io/kiss-ui)
+[`kiss-ui` docs hosted on Github Pages](http://kiss-ui.github.io/kiss-ui/doc/kiss_ui/)
 
 Usage
 -----


### PR DESCRIPTION
Uses the new http://kiss-ui.github.io/kiss-ui/doc/kiss_ui/ link instead. (Addresses issue #45)